### PR TITLE
Sync contact form 7 submissions offline

### DIFF
--- a/addweb-cf7-offline-sync/addweb-cf7-offline-sync.php
+++ b/addweb-cf7-offline-sync/addweb-cf7-offline-sync.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Plugin Name: AddWeb CF7 Offline Sync
+ * Description: Offline-first support for Contact Form 7 and generic forms. Caches pages for offline, queues submissions in IndexedDB, auto-syncs when online, with admin UI, CSV export, and REST API.
+ * Version: 1.0.0
+ * Author: AddWeb + GPT Assistant
+ * Text Domain: addweb-cf7-offline-sync
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+if ( ! defined( 'AFOS_PLUGIN_FILE' ) ) {
+    define( 'AFOS_PLUGIN_FILE', __FILE__ );
+}
+if ( ! defined( 'AFOS_PLUGIN_DIR' ) ) {
+    define( 'AFOS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+}
+if ( ! defined( 'AFOS_PLUGIN_URL' ) ) {
+    define( 'AFOS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+}
+if ( ! defined( 'AFOS_VERSION' ) ) {
+    define( 'AFOS_VERSION', '1.0.0' );
+}
+
+// Autoload includes
+require_once AFOS_PLUGIN_DIR . 'includes/class-afos-logger.php';
+require_once AFOS_PLUGIN_DIR . 'includes/class-afos-db.php';
+require_once AFOS_PLUGIN_DIR . 'includes/class-afos-service-worker.php';
+require_once AFOS_PLUGIN_DIR . 'includes/class-afos-rest.php';
+require_once AFOS_PLUGIN_DIR . 'includes/class-afos-admin.php';
+require_once AFOS_PLUGIN_DIR . 'includes/class-afos-cf7.php';
+require_once AFOS_PLUGIN_DIR . 'includes/class-afos-plugin.php';
+
+// Initialize plugin
+add_action( 'plugins_loaded', function () {
+    load_plugin_textdomain( 'addweb-cf7-offline-sync', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+
+    $plugin = \AFOS\Plugin::get_instance();
+    $plugin->init();
+});
+
+register_activation_hook( __FILE__, function () {
+    \AFOS\DB::maybe_create_tables();
+    // Set defaults if not present
+    $defaults = array(
+        'pages_to_cache'          => array(),
+        'enable_email'            => false,
+        'email_recipients'        => get_option( 'admin_email' ),
+        'sync_api_key'            => wp_generate_password( 20, false ),
+        'enable_debug_logging'    => true,
+        'auto_tag_cf7_forms'      => true,
+    );
+    foreach ( $defaults as $key => $value ) {
+        if ( get_option( 'afos_' . $key, null ) === null ) {
+            update_option( 'afos_' . $key, $value );
+        }
+    }
+});
+
+register_uninstall_hook( __FILE__, '\\AFOS\\DB::uninstall' );

--- a/addweb-cf7-offline-sync/assets/css/admin.css
+++ b/addweb-cf7-offline-sync/assets/css/admin.css
@@ -1,0 +1,10 @@
+/* AFOS Admin Styles */
+.afos-wrap { background: #fff; padding: 20px; border: 1px solid #ccd0d4; border-radius: 6px; }
+.afos-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.afos-card { background: #f8f9fa; border: 1px solid #e2e8f0; padding: 16px; border-radius: 6px; }
+.afos-table { width: 100%; border-collapse: collapse; }
+.afos-table th, .afos-table td { padding: 8px 10px; border-bottom: 1px solid #eee; text-align: left; }
+.afos-actions { margin-top: 16px; display: flex; gap: 12px; align-items: center; }
+.afos-notice { margin: 10px 0; padding: 10px 12px; border-radius: 4px; }
+.afos-notice.info { background:#e6f4ff; border:1px solid #90caf9; }
+.afos-notice.error { background:#ffebee; border:1px solid #ef9a9a; }

--- a/addweb-cf7-offline-sync/assets/js/offline-forms.js
+++ b/addweb-cf7-offline-sync/assets/js/offline-forms.js
@@ -1,0 +1,147 @@
+(function(){
+  'use strict';
+
+  const settings = (typeof AFOS_SETTINGS !== 'undefined') ? AFOS_SETTINGS : {};
+  const LOG_PREFIX = '[AFOS]';
+
+  function log(){ if(settings.enableDebug && console) { console.log(LOG_PREFIX, ...arguments); } }
+  function warn(){ if(console) { console.warn(LOG_PREFIX, ...arguments); } }
+
+  // IndexedDB wrapper
+  const DB_NAME = 'afos-db';
+  const STORE = 'queue';
+  const VERSION = 1;
+
+  function openDb(){
+    return new Promise((resolve, reject)=>{
+      const req = indexedDB.open(DB_NAME, VERSION);
+      req.onupgradeneeded = (e)=>{
+        const db = e.target.result;
+        if(!db.objectStoreNames.contains(STORE)){
+          db.createObjectStore(STORE, { keyPath: 'id', autoIncrement: true });
+        }
+      };
+      req.onsuccess = ()=> resolve(req.result);
+      req.onerror = ()=> reject(req.error);
+    });
+  }
+
+  function addToQueue(payload){
+    return openDb().then(db=> new Promise((resolve, reject)=>{
+      const tx = db.transaction(STORE, 'readwrite');
+      tx.oncomplete = ()=> resolve();
+      tx.onerror = ()=> reject(tx.error);
+      tx.objectStore(STORE).add(payload);
+    }));
+  }
+
+  function getAllQueued(){
+    return openDb().then(db=> new Promise((resolve, reject)=>{
+      const tx = db.transaction(STORE, 'readonly');
+      const store = tx.objectStore(STORE);
+      const items = [];
+      store.openCursor().onsuccess = (e)=>{
+        const cursor = e.target.result;
+        if(cursor){ items.push(cursor.value); cursor.continue(); } else { resolve(items); }
+      };
+      tx.onerror = ()=> reject(tx.error);
+    }));
+  }
+
+  function removeFromQueue(id){
+    return openDb().then(db=> new Promise((resolve, reject)=>{
+      const tx = db.transaction(STORE, 'readwrite');
+      tx.oncomplete = ()=> resolve();
+      tx.onerror = ()=> reject(tx.error);
+      tx.objectStore(STORE).delete(id);
+    }));
+  }
+
+  async function syncQueued(){
+    if(!navigator.onLine){ return; }
+    const items = await getAllQueued();
+    for(const item of items){
+      try {
+        await syncOne(item);
+        await removeFromQueue(item.id);
+        log('Synced queued submission', item);
+      } catch(e){
+        warn('Sync failed, will retry later', e);
+      }
+    }
+  }
+
+  function buildPayload(form){
+    const formData = new FormData(form);
+    const fields = {};
+    for(const [k,v] of formData.entries()){
+      if(k.startsWith('_')) continue; // CF7 internals
+      if(fields[k]){
+        if(Array.isArray(fields[k])) fields[k].push(v); else fields[k] = [fields[k], v];
+      } else {
+        fields[k] = v;
+      }
+    }
+    const formIdEl = form.querySelector('input[name="_wpcf7"]');
+    const formId = formIdEl ? parseInt(formIdEl.value, 10) : undefined;
+    const titleEl = form.querySelector('input[name="_wpcf7_unit_tag"], input[name="_wpcf7_container_post"]');
+    return { form_id: formId, form_title: document.title, fields, source: 'offline' };
+  }
+
+  async function syncOne(item){
+    const url = settings.restUrl.replace(/\/$/, '') + '/submissions';
+    const res = await fetch(url + '?_locale=user', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-afos-api-key': settings.apiKey || '',
+      },
+      body: JSON.stringify({ form_id: item.form_id, form_title: item.form_title, fields: item.fields, source: 'offline' })
+    });
+    if(!res.ok){ throw new Error('HTTP '+res.status); }
+    return res.json();
+  }
+
+  function showNotice(form, message, type){
+    const el = document.createElement('div');
+    el.className = 'afos-notice ' + (type||'info');
+    el.textContent = message;
+    form.parentNode.insertBefore(el, form);
+    setTimeout(()=>{ el.remove(); }, 5000);
+  }
+
+  function handleSubmit(e){
+    const form = e.target;
+    if(!form || form.getAttribute('data-offline-form') !== 'true') return;
+    if(navigator.onLine) return; // let normal submit
+    e.preventDefault();
+    try {
+      const payload = buildPayload(form);
+      addToQueue(payload).then(()=>{
+        showNotice(form, form.getAttribute('data-offline-message') || 'You are offline. Your submission is saved and will be sent automatically when online.', 'info');
+        form.reset();
+        syncQueued();
+      }).catch((err)=>{
+        showNotice(form, 'Failed to save offline. Please try again later.', 'error');
+        warn('Queue add failed', err);
+      });
+    } catch(err){ warn('handleSubmit error', err); }
+  }
+
+  function registerSW(){
+    if('serviceWorker' in navigator){
+      navigator.serviceWorker.register(settings.swUrl).catch(()=>{});
+    }
+  }
+
+  function init(){
+    registerSW();
+    document.addEventListener('submit', handleSubmit, true);
+    window.addEventListener('online', ()=> { setTimeout(syncQueued, 1000); });
+    setTimeout(syncQueued, 2000);
+  }
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', init);
+  } else { init(); }
+})();

--- a/addweb-cf7-offline-sync/includes/class-afos-admin.php
+++ b/addweb-cf7-offline-sync/includes/class-afos-admin.php
@@ -1,0 +1,70 @@
+<?php
+namespace AFOS;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Admin {
+    public function hooks(): void {
+        add_action( 'admin_menu', [ $this, 'menu' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin' ] );
+    }
+
+    public function enqueue_admin( string $hook ): void {
+        if ( strpos( $hook, 'afos' ) === false ) { return; }
+        wp_enqueue_style( 'afos-admin', AFOS_PLUGIN_URL . 'assets/css/admin.css', array(), AFOS_VERSION );
+    }
+
+    public function menu(): void {
+        add_menu_page(
+            __( 'CF7 Offline Sync', 'addweb-cf7-offline-sync' ),
+            __( 'CF7 Offline Sync', 'addweb-cf7-offline-sync' ),
+            'manage_options',
+            'afos',
+            [ $this, 'render_settings' ],
+            'dashicons-cloud',
+            56
+        );
+        add_submenu_page( 'afos', __( 'Submissions', 'addweb-cf7-offline-sync' ), __( 'Submissions', 'addweb-cf7-offline-sync' ), 'manage_options', 'afos-submissions', [ $this, 'render_submissions' ] );
+        add_submenu_page( 'afos', __( 'Logs', 'addweb-cf7-offline-sync' ), __( 'Logs', 'addweb-cf7-offline-sync' ), 'manage_options', 'afos-logs', [ $this, 'render_logs' ] );
+    }
+
+    public function register_settings(): void {
+        register_setting( 'afos_settings', 'afos_pages_to_cache', array( 'type' => 'array', 'sanitize_callback' => [ $this, 'sanitize_pages' ] ) );
+        register_setting( 'afos_settings', 'afos_enable_email', array( 'type' => 'boolean', 'sanitize_callback' => 'rest_sanitize_boolean' ) );
+        register_setting( 'afos_settings', 'afos_email_recipients', array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ) );
+        register_setting( 'afos_settings', 'afos_sync_api_key', array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ) );
+        register_setting( 'afos_settings', 'afos_enable_debug_logging', array( 'type' => 'boolean', 'sanitize_callback' => 'rest_sanitize_boolean' ) );
+        register_setting( 'afos_settings', 'afos_auto_tag_cf7_forms', array( 'type' => 'boolean', 'sanitize_callback' => 'rest_sanitize_boolean' ) );
+    }
+
+    public function sanitize_pages( $value ) {
+        $ids = array();
+        if ( is_array( $value ) ) {
+            foreach ( $value as $id ) { $ids[] = (int) $id; }
+        }
+        return $ids;
+    }
+
+    public function render_settings(): void {
+        if ( ! current_user_can( 'manage_options' ) ) { return; }
+        include AFOS_PLUGIN_DIR . 'views/settings.php';
+    }
+
+    public function render_submissions(): void {
+        if ( ! current_user_can( 'manage_options' ) ) { return; }
+        $paged       = isset( $_GET['paged'] ) ? max( 1, (int) $_GET['paged'] ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $per_page    = 20;
+        $submissions = DB::get_submissions( $paged, $per_page );
+        $total       = DB::count_submissions();
+        include AFOS_PLUGIN_DIR . 'views/submissions.php';
+    }
+
+    public function render_logs(): void {
+        if ( ! current_user_can( 'manage_options' ) ) { return; }
+        global $wpdb;
+        $table = Logger::logs_table();
+        $logs  = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY id DESC LIMIT 200", ARRAY_A );
+        include AFOS_PLUGIN_DIR . 'views/logs.php';
+    }
+}

--- a/addweb-cf7-offline-sync/includes/class-afos-cf7.php
+++ b/addweb-cf7-offline-sync/includes/class-afos-cf7.php
@@ -1,0 +1,45 @@
+<?php
+namespace AFOS;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class CF7 {
+    public function hooks(): void {
+        add_filter( 'wpcf7_form_attributes', [ $this, 'add_form_attribute' ] );
+        add_action( 'wpcf7_submit', [ $this, 'capture_submission' ], 10, 2 );
+    }
+
+    public function add_form_attribute( array $atts ): array {
+        $auto = (bool) get_option( 'afos_auto_tag_cf7_forms', true );
+        if ( $auto ) {
+            $atts['data-offline-form'] = 'true';
+        }
+        return $atts;
+    }
+
+    public function capture_submission( $contact_form, $result ): void { // phpcs:ignore
+        try {
+            $submission = \WPCF7_Submission::get_instance();
+            if ( ! $submission ) { return; }
+            $posted_data = (array) $submission->get_posted_data();
+            $form_id     = method_exists( $contact_form, 'id' ) ? (int) $contact_form->id() : 0;
+            $form_title  = method_exists( $contact_form, 'title' ) ? (string) $contact_form->title() : '';
+
+            // Remove CF7 internal fields
+            $fields = array();
+            foreach ( $posted_data as $k => $v ) {
+                if ( strpos( (string) $k, '_' ) === 0 ) { continue; }
+                $fields[ sanitize_key( (string) $k ) ] = is_array( $v ) ? array_map( 'sanitize_text_field', array_map( 'strval', $v ) ) : sanitize_text_field( (string) $v );
+            }
+            DB::insert_submission( array(
+                'form_id'    => $form_id,
+                'form_title' => $form_title,
+                'fields'     => $fields,
+                'status'     => ( isset( $result['status'] ) && $result['status'] === 'mail_sent' ) ? 'online' : 'failed',
+                'source'     => 'online',
+            ) );
+        } catch ( \Throwable $e ) {
+            Logger::error( 'CF7 capture failed', array( 'error' => $e->getMessage() ) );
+        }
+    }
+}

--- a/addweb-cf7-offline-sync/includes/class-afos-db.php
+++ b/addweb-cf7-offline-sync/includes/class-afos-db.php
@@ -1,0 +1,135 @@
+<?php
+namespace AFOS;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class DB {
+    public static function maybe_create_tables(): void {
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        global $wpdb;
+
+        $charset_collate = $wpdb->get_charset_collate();
+        $submissions     = self::submissions_table();
+        $logs            = Logger::logs_table();
+
+        $sql = "CREATE TABLE {$submissions} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            form_id BIGINT UNSIGNED NULL,
+            form_title VARCHAR(255) NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'queued',
+            source VARCHAR(20) NOT NULL DEFAULT 'offline',
+            fields LONGTEXT NULL,
+            errors LONGTEXT NULL,
+            created_at DATETIME NOT NULL,
+            synced_at DATETIME NULL,
+            PRIMARY KEY (id),
+            KEY form_id (form_id),
+            KEY status (status)
+        ) {$charset_collate};";
+
+        $sql2 = "CREATE TABLE {$logs} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            level VARCHAR(20) NOT NULL,
+            message TEXT NOT NULL,
+            context LONGTEXT NULL,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            KEY level (level)
+        ) {$charset_collate};";
+
+        dbDelta( $sql );
+        dbDelta( $sql2 );
+    }
+
+    public static function uninstall(): void {
+        global $wpdb;
+        $wpdb->query( 'DROP TABLE IF EXISTS ' . self::submissions_table() );
+        $wpdb->query( 'DROP TABLE IF EXISTS ' . Logger::logs_table() );
+        delete_option( 'afos_pages_to_cache' );
+        delete_option( 'afos_enable_email' );
+        delete_option( 'afos_email_recipients' );
+        delete_option( 'afos_sync_api_key' );
+        delete_option( 'afos_enable_debug_logging' );
+        delete_option( 'afos_auto_tag_cf7_forms' );
+    }
+
+    public static function submissions_table(): string {
+        global $wpdb;
+        return $wpdb->prefix . 'afos_submissions';
+    }
+
+    public static function insert_submission( array $args ): int {
+        global $wpdb;
+        $table = self::submissions_table();
+        $data  = array(
+            'form_id'    => isset( $args['form_id'] ) ? (int) $args['form_id'] : null,
+            'form_title' => isset( $args['form_title'] ) ? sanitize_text_field( (string) $args['form_title'] ) : null,
+            'status'     => isset( $args['status'] ) ? sanitize_text_field( (string) $args['status'] ) : 'queued',
+            'source'     => isset( $args['source'] ) ? sanitize_text_field( (string) $args['source'] ) : 'offline',
+            'fields'     => isset( $args['fields'] ) ? wp_json_encode( $args['fields'] ) : null,
+            'errors'     => isset( $args['errors'] ) ? wp_json_encode( $args['errors'] ) : null,
+            'created_at' => current_time( 'mysql', 1 ),
+            'synced_at'  => null,
+        );
+        $wpdb->insert( $table, $data );
+        return (int) $wpdb->insert_id;
+    }
+
+    public static function update_submission_status( int $id, string $status, ?string $error = null ): void {
+        global $wpdb;
+        $table = self::submissions_table();
+        $data  = array( 'status' => sanitize_text_field( $status ) );
+        if ( $status === 'synced' ) {
+            $data['synced_at'] = current_time( 'mysql', 1 );
+        }
+        if ( $error ) {
+            $data['errors'] = wp_json_encode( array( 'message' => wp_strip_all_tags( $error ) ) );
+        }
+        $wpdb->update( $table, $data, array( 'id' => $id ), null, array( '%d' ) );
+    }
+
+    public static function get_submissions( int $paged = 1, int $per_page = 20 ): array {
+        global $wpdb;
+        $table  = self::submissions_table();
+        $offset = max( 0, ( $paged - 1 ) * $per_page );
+        $rows   = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} ORDER BY id DESC LIMIT %d OFFSET %d", $per_page, $offset ), ARRAY_A );
+        return array_map( [ __CLASS__, 'prepare_submission_row' ], $rows );
+    }
+
+    public static function count_submissions(): int {
+        global $wpdb;
+        $table = self::submissions_table();
+        return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" );
+    }
+
+    public static function prepare_submission_row( array $row ): array {
+        $row['id']         = (int) $row['id'];
+        $row['form_id']    = isset( $row['form_id'] ) ? (int) $row['form_id'] : null;
+        $row['form_title'] = isset( $row['form_title'] ) ? (string) $row['form_title'] : '';
+        $row['fields']     = ! empty( $row['fields'] ) ? json_decode( (string) $row['fields'], true ) : array();
+        $row['errors']     = ! empty( $row['errors'] ) ? json_decode( (string) $row['errors'], true ) : array();
+        return $row;
+    }
+
+    public static function export_csv(): string {
+        $rows = self::get_submissions( 1, 10000 );
+        $fh   = fopen( 'php://temp', 'w+' );
+        fputcsv( $fh, array( 'ID', 'Form ID', 'Form Title', 'Status', 'Source', 'Fields', 'Created At', 'Synced At' ) );
+        foreach ( $rows as $r ) {
+            fputcsv( $fh, array(
+                $r['id'],
+                $r['form_id'],
+                $r['form_title'],
+                $r['status'],
+                $r['source'],
+                wp_json_encode( $r['fields'] ),
+                $r['created_at'],
+                $r['synced_at'],
+            ) );
+        }
+        rewind( $fh );
+        $csv = stream_get_contents( $fh );
+        fclose( $fh );
+        return (string) $csv;
+    }
+}

--- a/addweb-cf7-offline-sync/includes/class-afos-logger.php
+++ b/addweb-cf7-offline-sync/includes/class-afos-logger.php
@@ -1,0 +1,71 @@
+<?php
+namespace AFOS;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Logger {
+    public const LEVEL_DEBUG = 'debug';
+    public const LEVEL_INFO  = 'info';
+    public const LEVEL_WARN  = 'warning';
+    public const LEVEL_ERROR = 'error';
+
+    public static function debug( string $message, array $context = array() ): void {
+        self::log( self::LEVEL_DEBUG, $message, $context );
+    }
+    public static function info( string $message, array $context = array() ): void {
+        self::log( self::LEVEL_INFO, $message, $context );
+    }
+    public static function warning( string $message, array $context = array() ): void {
+        self::log( self::LEVEL_WARN, $message, $context );
+    }
+    public static function error( string $message, array $context = array() ): void {
+        self::log( self::LEVEL_ERROR, $message, $context );
+    }
+
+    public static function log( string $level, string $message, array $context = array() ): void {
+        $enable_db   = true;
+        $enable_file = defined( 'WP_DEBUG' ) && WP_DEBUG;
+
+        $sanitized_message = wp_strip_all_tags( $message );
+        $json_context      = wp_json_encode( self::sanitize_context( $context ) );
+
+        global $wpdb;
+        if ( $enable_db && isset( $wpdb ) ) {
+            $table = self::logs_table();
+            if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
+                $wpdb->insert(
+                    $table,
+                    array(
+                        'level'      => $level,
+                        'message'    => $sanitized_message,
+                        'context'    => $json_context,
+                        'created_at' => current_time( 'mysql', 1 ),
+                    ),
+                    array( '%s', '%s', '%s', '%s' )
+                );
+            }
+        }
+
+        if ( $enable_file ) {
+            error_log( sprintf( '[AFOS][%s] %s %s', strtoupper( $level ), $sanitized_message, $json_context ) );
+        }
+    }
+
+    private static function sanitize_context( array $context ): array {
+        $clean = array();
+        foreach ( $context as $key => $value ) {
+            $safe_key = sanitize_key( (string) $key );
+            if ( is_scalar( $value ) ) {
+                $clean[ $safe_key ] = is_string( $value ) ? sanitize_text_field( $value ) : $value;
+            } else {
+                $clean[ $safe_key ] = $value; // wp_json_encode will handle
+            }
+        }
+        return $clean;
+    }
+
+    public static function logs_table(): string {
+        global $wpdb;
+        return $wpdb->prefix . 'afos_logs';
+    }
+}

--- a/addweb-cf7-offline-sync/includes/class-afos-plugin.php
+++ b/addweb-cf7-offline-sync/includes/class-afos-plugin.php
@@ -1,0 +1,68 @@
+<?php
+namespace AFOS;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Plugin {
+    private static $instance = null;
+
+    public static function get_instance(): Plugin {
+        if ( self::$instance === null ) {
+            self::$instance = new Plugin();
+        }
+        return self::$instance;
+    }
+
+    public function init(): void {
+        // Admin UI
+        ( new Admin() )->hooks();
+        // REST endpoints
+        ( new Rest() )->hooks();
+        // Service Worker endpoint
+        ( new Service_Worker() )->hooks();
+        // CF7 integration
+        ( new CF7() )->hooks();
+
+        // Frontend assets
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend' ] );
+
+        // Log that plugin initialized
+        Logger::info( 'AFOS plugin initialized', [ 'version' => AFOS_VERSION ] );
+    }
+
+    public function enqueue_frontend(): void {
+        $handle = 'afos-offline-forms';
+        wp_register_script(
+            $handle,
+            AFOS_PLUGIN_URL . 'assets/js/offline-forms.js',
+            array(),
+            AFOS_VERSION,
+            true
+        );
+
+        $pages_to_cache = get_option( 'afos_pages_to_cache', array() );
+        $page_urls      = array();
+        if ( is_array( $pages_to_cache ) ) {
+            foreach ( $pages_to_cache as $page_id ) {
+                $url = get_permalink( (int) $page_id );
+                if ( $url ) {
+                    $page_urls[] = esc_url_raw( $url );
+                }
+            }
+        }
+
+        wp_localize_script( $handle, 'AFOS_SETTINGS', array(
+            'restUrl'        => esc_url_raw( rest_url( 'addweb-cf7/v1' ) ),
+            'swUrl'          => esc_url_raw( admin_url( 'admin-ajax.php?action=afos_sw' ) ),
+            'nonce'          => wp_create_nonce( 'wp_rest' ),
+            'apiKey'         => (string) get_option( 'afos_sync_api_key', '' ),
+            'pagesToCache'   => $page_urls,
+            'enableDebug'    => (bool) get_option( 'afos_enable_debug_logging', false ),
+            'textDomain'     => 'addweb-cf7-offline-sync',
+        ) );
+
+        wp_enqueue_script( $handle );
+    }
+}

--- a/addweb-cf7-offline-sync/includes/class-afos-rest.php
+++ b/addweb-cf7-offline-sync/includes/class-afos-rest.php
@@ -1,0 +1,123 @@
+<?php
+namespace AFOS;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Rest {
+    public function hooks(): void {
+        add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+    }
+
+    public function register_routes(): void {
+        register_rest_route( 'addweb-cf7/v1', '/submissions', array(
+            array(
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'create_submission' ],
+                'permission_callback' => '__return_true',
+                'args'                => array(
+                    'form_id' => array( 'type' => 'integer', 'required' => false ),
+                    'form_title' => array( 'type' => 'string', 'required' => false ),
+                    'fields'  => array( 'type' => 'object', 'required' => true ),
+                    'source'  => array( 'type' => 'string', 'required' => false ),
+                ),
+            ),
+            array(
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'list_submissions' ],
+                'permission_callback' => function(){ return current_user_can( 'manage_options' ); },
+            ),
+        ) );
+
+        register_rest_route( 'addweb-cf7/v1', '/export', array(
+            array(
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'export_csv' ],
+                'permission_callback' => function(){ return current_user_can( 'manage_options' ); },
+            ),
+        ) );
+    }
+
+    private function validate_api_key( WP_REST_Request $request ): bool {
+        $key     = (string) get_option( 'afos_sync_api_key', '' );
+        $header  = sanitize_text_field( (string) $request->get_header( 'x-afos-api-key' ) );
+        $query   = sanitize_text_field( (string) $request->get_param( 'api_key' ) );
+        $provided = $header ?: $query;
+        if ( empty( $key ) ) { return false; }
+        return hash_equals( $key, (string) $provided );
+    }
+
+    public function create_submission( WP_REST_Request $request ) {
+        if ( ! $this->validate_api_key( $request ) ) {
+            Logger::warning( 'Unauthorized submission attempt' );
+            return new WP_Error( 'afos_forbidden', __( 'Invalid API key.', 'addweb-cf7-offline-sync' ), array( 'status' => 403 ) );
+        }
+
+        $form_id    = (int) $request->get_param( 'form_id' );
+        $form_title = sanitize_text_field( (string) $request->get_param( 'form_title' ) );
+        $fields     = (array) $request->get_param( 'fields' );
+        $source     = sanitize_text_field( (string) ( $request->get_param( 'source' ) ?: 'offline' ) );
+
+        $id = DB::insert_submission( array(
+            'form_id'    => $form_id ?: null,
+            'form_title' => $form_title ?: null,
+            'fields'     => $fields,
+            'status'     => 'synced',
+            'source'     => $source,
+        ) );
+
+        // Email notifications if enabled
+        if ( get_option( 'afos_enable_email', false ) ) {
+            try {
+                $to      = (string) get_option( 'afos_email_recipients', get_option( 'admin_email' ) );
+                $subject = sprintf( __( 'Offline submission synced (ID %d)', 'addweb-cf7-offline-sync' ), $id );
+                $body    = $this->format_fields_for_email( $fields, $form_title, $form_id );
+                wp_mail( $to, $subject, $body );
+            } catch ( \Throwable $e ) {
+                Logger::error( 'Email notification failed', array( 'error' => $e->getMessage() ) );
+            }
+        }
+
+        Logger::info( 'Submission synced', array( 'id' => $id, 'form_id' => $form_id ) );
+        return new WP_REST_Response( array( 'id' => $id, 'status' => 'synced' ), 201 );
+    }
+
+    private function format_fields_for_email( array $fields, string $form_title = '', int $form_id = 0 ): string {
+        $lines   = array();
+        $header  = __( 'Offline submission details', 'addweb-cf7-offline-sync' );
+        $lines[] = $header;
+        if ( $form_title ) { $lines[] = sprintf( __( 'Form: %s', 'addweb-cf7-offline-sync' ), $form_title ); }
+        if ( $form_id ) { $lines[] = sprintf( __( 'Form ID: %d', 'addweb-cf7-offline-sync' ), $form_id ); }
+        $lines[] = str_repeat( '-', 30 );
+        foreach ( $fields as $key => $value ) {
+            $label = sanitize_text_field( (string) $key );
+            if ( is_array( $value ) ) {
+                $value = implode( ', ', array_map( 'sanitize_text_field', array_map( 'strval', $value ) ) );
+            } else {
+                $value = sanitize_text_field( (string) $value );
+            }
+            $lines[] = $label . ': ' . $value;
+        }
+        return implode( "\n", $lines );
+    }
+
+    public function list_submissions( WP_REST_Request $request ) {
+        $paged    = max( 1, (int) $request->get_param( 'page' ) );
+        $per_page = min( 100, max( 1, (int) $request->get_param( 'per_page' ) ) );
+        $rows     = DB::get_submissions( $paged, $per_page );
+        $total    = DB::count_submissions();
+        return new WP_REST_Response( array( 'data' => $rows, 'total' => $total ), 200 );
+    }
+
+    public function export_csv( WP_REST_Request $request ) {
+        $csv = DB::export_csv();
+        return new WP_REST_Response( $csv, 200, array(
+            'Content-Type'        => 'text/csv; charset=utf-8',
+            'Content-Disposition' => 'attachment; filename="afos-submissions.csv"',
+        ) );
+    }
+}

--- a/addweb-cf7-offline-sync/includes/class-afos-service-worker.php
+++ b/addweb-cf7-offline-sync/includes/class-afos-service-worker.php
@@ -1,0 +1,80 @@
+<?php
+namespace AFOS;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Service_Worker {
+    public function hooks(): void {
+        add_action( 'wp_head', [ $this, 'inject_sw_registration' ] );
+        add_action( 'wp_ajax_afos_sw', [ $this, 'render_sw' ] );
+        add_action( 'wp_ajax_nopriv_afos_sw', [ $this, 'render_sw' ] );
+    }
+
+    public function inject_sw_registration(): void {
+        // Small inline registration for PWA
+        echo '<script>if("serviceWorker" in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register(' . wp_json_encode( admin_url( 'admin-ajax.php?action=afos_sw' ) ) . ').catch(function(e){console.warn("AFOS SW reg failed",e);});});}</script>';
+    }
+
+    public function render_sw(): void {
+        header( 'Content-Type: application/javascript; charset=utf-8' );
+        header( 'Service-Worker-Allowed: /' );
+
+        $cache_key = 'afos-cache-v' . sanitize_key( AFOS_VERSION );
+        $pages     = get_option( 'afos_pages_to_cache', array() );
+        $urls      = array();
+        if ( is_array( $pages ) ) {
+            foreach ( $pages as $page_id ) {
+                $url = get_permalink( (int) $page_id );
+                if ( $url ) {
+                    $urls[] = esc_url_raw( $url );
+                }
+            }
+        }
+        // include plugin assets
+        $urls[] = esc_url_raw( AFOS_PLUGIN_URL . 'assets/js/offline-forms.js' );
+
+        $precache = wp_json_encode( array_values( array_unique( $urls ) ) );
+
+        echo "const AFOS_CACHE='{$cache_key}';\n";
+        echo "const AFOS_PRECACHE={$precache};\n";
+        echo <<<'JS'
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(AFOS_CACHE).then((cache) => cache.addAll(AFOS_PRECACHE)).catch((e)=>{})
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys)=>Promise.all(keys.map((k)=>{if(k!==AFOS_CACHE){return caches.delete(k)}})))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  const url = new URL(req.url);
+  if (req.method === 'GET' && (url.origin === self.location.origin)) {
+    // Cache-first for same-origin pages and assets
+    event.respondWith(
+      caches.match(req).then((cached)=>{
+        if (cached) return cached;
+        return fetch(req).then((res)=>{
+          const resClone = res.clone();
+          caches.open(AFOS_CACHE).then((cache)=>{ cache.put(req, resClone); });
+          return res;
+        }).catch(()=>{
+          // Offline fallback for HTML
+          if (req.headers.get('accept') && req.headers.get('accept').includes('text/html')) {
+            return caches.match('/');
+          }
+        });
+      })
+    );
+  }
+});
+JS;
+        exit;
+    }
+}

--- a/addweb-cf7-offline-sync/views/logs.php
+++ b/addweb-cf7-offline-sync/views/logs.php
@@ -1,0 +1,26 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+?>
+<div class="wrap afos-wrap">
+    <h1><?php echo esc_html__( 'Logs', 'addweb-cf7-offline-sync' ); ?></h1>
+    <table class="afos-table">
+        <thead>
+            <tr>
+                <th><?php echo esc_html__( 'Time', 'addweb-cf7-offline-sync' ); ?></th>
+                <th><?php echo esc_html__( 'Level', 'addweb-cf7-offline-sync' ); ?></th>
+                <th><?php echo esc_html__( 'Message', 'addweb-cf7-offline-sync' ); ?></th>
+                <th><?php echo esc_html__( 'Context', 'addweb-cf7-offline-sync' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ( $logs as $log ) : ?>
+                <tr>
+                    <td><?php echo esc_html( $log['created_at'] ); ?></td>
+                    <td><?php echo esc_html( strtoupper( $log['level'] ) ); ?></td>
+                    <td><?php echo esc_html( $log['message'] ); ?></td>
+                    <td><pre><?php echo esc_html( $log['context'] ); ?></pre></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/addweb-cf7-offline-sync/views/settings.php
+++ b/addweb-cf7-offline-sync/views/settings.php
@@ -1,0 +1,57 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+$pages_to_cache       = (array) get_option( 'afos_pages_to_cache', array() );
+$enable_email         = (bool) get_option( 'afos_enable_email', false );
+$email_recipients     = (string) get_option( 'afos_email_recipients', get_option( 'admin_email' ) );
+srand();
+$sync_api_key         = (string) get_option( 'afos_sync_api_key', '' );
+$enable_debug_logging = (bool) get_option( 'afos_enable_debug_logging', false );
+$auto_tag_cf7_forms   = (bool) get_option( 'afos_auto_tag_cf7_forms', true );
+$pages = get_pages();
+?>
+<div class="wrap afos-wrap">
+    <h1><?php echo esc_html__( 'CF7 Offline Sync - Settings', 'addweb-cf7-offline-sync' ); ?></h1>
+    <form method="post" action="options.php">
+        <?php settings_fields( 'afos_settings' ); ?>
+        <div class="afos-grid">
+            <div class="afos-card">
+                <h2><?php echo esc_html__( 'Offline Caching', 'addweb-cf7-offline-sync' ); ?></h2>
+                <p><?php echo esc_html__( 'Select pages to cache for offline access.', 'addweb-cf7-offline-sync' ); ?></p>
+                <select multiple name="afos_pages_to_cache[]" style="width:100%; min-height:160px;">
+                    <?php foreach ( $pages as $p ) : ?>
+                        <option value="<?php echo (int) $p->ID; ?>" <?php selected( in_array( $p->ID, $pages_to_cache, true ) ); ?>>
+                            <?php echo esc_html( $p->post_title ); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="afos-card">
+                <h2><?php echo esc_html__( 'Email Notifications', 'addweb-cf7-offline-sync' ); ?></h2>
+                <p><label><input type="checkbox" name="afos_enable_email" value="1" <?php checked( $enable_email ); ?>> <?php echo esc_html__( 'Enable email on sync', 'addweb-cf7-offline-sync' ); ?></label></p>
+                <p>
+                    <label><?php echo esc_html__( 'Recipients (comma-separated)', 'addweb-cf7-offline-sync' ); ?></label>
+                    <input type="text" name="afos_email_recipients" value="<?php echo esc_attr( $email_recipients ); ?>" class="regular-text" />
+                </p>
+            </div>
+            <div class="afos-card">
+                <h2><?php echo esc_html__( 'Security & Debug', 'addweb-cf7-offline-sync' ); ?></h2>
+                <p><label><?php echo esc_html__( 'Sync API Key', 'addweb-cf7-offline-sync' ); ?></label></p>
+                <p>
+                    <input type="text" readonly value="<?php echo esc_attr( $sync_api_key ); ?>" class="regular-text" />
+                    <em><?php echo esc_html__( 'Used by the client to authenticate offline sync requests.', 'addweb-cf7-offline-sync' ); ?></em>
+                </p>
+                <p><label><input type="checkbox" name="afos_enable_debug_logging" value="1" <?php checked( $enable_debug_logging ); ?>> <?php echo esc_html__( 'Enable debug logging', 'addweb-cf7-offline-sync' ); ?></label></p>
+                <p><label><input type="checkbox" name="afos_auto_tag_cf7_forms" value="1" <?php checked( $auto_tag_cf7_forms ); ?>> <?php echo esc_html__( 'Auto-enable offline on all CF7 forms', 'addweb-cf7-offline-sync' ); ?></label></p>
+            </div>
+        </div>
+        <p class="afos-actions">
+            <?php submit_button( __( 'Save Settings', 'addweb-cf7-offline-sync' ), 'primary', 'submit', false ); ?>
+            <a class="button" href="<?php echo esc_url( rest_url( 'addweb-cf7/v1/export' ) ); ?>"><?php echo esc_html__( 'Export CSV', 'addweb-cf7-offline-sync' ); ?></a>
+        </p>
+    </form>
+    <hr/>
+    <p>
+        <strong><?php echo esc_html__( 'How to use:', 'addweb-cf7-offline-sync' ); ?></strong>
+        <?php echo esc_html__( 'All Contact Form 7 forms are automatically enabled for offline. If you use a custom form, add data-offline-form="true" attribute to the <form> tag.', 'addweb-cf7-offline-sync' ); ?>
+    </p>
+</div>

--- a/addweb-cf7-offline-sync/views/submissions.php
+++ b/addweb-cf7-offline-sync/views/submissions.php
@@ -1,0 +1,42 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+$total_pages = max( 1, (int) ceil( $total / 20 ) );
+$current_url = esc_url( add_query_arg( array() ) );
+?>
+<div class="wrap afos-wrap">
+    <h1><?php echo esc_html__( 'Submissions', 'addweb-cf7-offline-sync' ); ?></h1>
+    <table class="afos-table">
+        <thead>
+            <tr>
+                <th><?php echo esc_html__( 'ID', 'addweb-cf7-offline-sync' ); ?></th>
+                <th><?php echo esc_html__( 'Form', 'addweb-cf7-offline-sync' ); ?></th>
+                <th><?php echo esc_html__( 'Status', 'addweb-cf7-offline-sync' ); ?></th>
+                <th><?php echo esc_html__( 'Source', 'addweb-cf7-offline-sync' ); ?></th>
+                <th><?php echo esc_html__( 'Created', 'addweb-cf7-offline-sync' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ( $submissions as $row ) : ?>
+                <tr>
+                    <td><?php echo (int) $row['id']; ?></td>
+                    <td>
+                        <?php echo esc_html( $row['form_title'] ?: ( $row['form_id'] ? ( 'ID ' . (int) $row['form_id'] ) : '-' ) ); ?>
+                        <details><summary><?php echo esc_html__( 'View Fields', 'addweb-cf7-offline-sync' ); ?></summary>
+                            <pre><?php echo esc_html( wp_json_encode( $row['fields'], JSON_PRETTY_PRINT ) ); ?></pre>
+                        </details>
+                    </td>
+                    <td><?php echo esc_html( $row['status'] ); ?></td>
+                    <td><?php echo esc_html( $row['source'] ); ?></td>
+                    <td><?php echo esc_html( $row['created_at'] ); ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php if ( $total_pages > 1 ) : ?>
+        <p class="tablenav-pages">
+            <?php for ( $i = 1; $i <= $total_pages; $i++ ) : ?>
+                <a class="button <?php echo $i === $paged ? 'button-primary' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'paged', $i, $current_url ) ); ?>"><?php echo (int) $i; ?></a>
+            <?php endfor; ?>
+        </p>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
Adds a WordPress plugin to enable offline form submissions for Contact Form 7 and other forms, with PWA caching and automatic online synchronization.

---
<a href="https://cursor.com/background-agent?bcId=bc-ffb70417-3df7-4818-8ab9-645b7863da86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ffb70417-3df7-4818-8ab9-645b7863da86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

